### PR TITLE
Interrupt dispatcher indirection

### DIFF
--- a/lib/include/risc5.h
+++ b/lib/include/risc5.h
@@ -7,10 +7,11 @@
 
 #include <stdint.h>
 
+/*********************************************************************************************************************/
 /*** Interrupts ***/
 
 /* interrupt vector table */
-extern uint32_t risc5_ivt[16];  /* defined in crt0.s */
+extern void (*risc5_ivt[16])(void);  /* defined in crt0.s */
 
 /* IRQ numbers */
 #define RISC5_IRQ_HP_TIMER      (15U)
@@ -19,6 +20,7 @@ extern uint32_t risc5_ivt[16];  /* defined in crt0.s */
 #define RISC5_IRQ_RS232_0_TX    (6U)
 #define RISC5_IRQ_BUTTONS       (3U)
 
+/*********************************************************************************************************************/
 /*** Devices ***/
 
 /* Device base addresses */
@@ -45,6 +47,7 @@ extern uint32_t risc5_ivt[16];  /* defined in crt0.s */
 #define RISC5_IO_LCD_DATA               ((volatile uint32_t*)((RISC5_XIO_BASE) + (4*2)))
 #define RISC5_IO_LCD_STAT_CTRL          ((volatile uint32_t*)((RISC5_XIO_BASE) + (4*3)))
 
+/*********************************************************************************************************************/
 /*** Cpu Intrinsics ***/
 
 extern void _asm_CLI(void);
@@ -54,5 +57,53 @@ extern void _asm_NOP(void);
 #define RISC5_DISABLE_INTERRUPTS() _asm_CLI()
 #define RISC5_ENABLE_INTERRUPTS() _asm_STI()
 #define RISC5_NOP() _asm_NOP()
+
+/*********************************************************************************************************************/
+/*** Interrupt dispatch ***/
+
+/*
+ * The default interrupt dispatching behaviour can be overwritten
+ * by writing a jump instruction to a user provided dispatcher at
+ * address 4 (risc5_start_irq_dispatch).
+ * 
+ * To do so, the macro RISC5_SET_IRQ_DISPATCHER(dispatcher_adress) 
+ * is provided, which correctly encodes the jump to the new dispatcher.
+ * 
+ * Example:
+ *      extern void(*my_dispatcher)(void);
+ *      uint32_t old_jump_instruction = risc5_start_irq_dispatch;
+ *      RISC5_SET_IRQ_DISPATCHER(my_dispatcher);
+ * 
+ * NOTE: The dispatcher is not a normal function and should be written 
+ *       in assembly language. See `risc5_default_irq_dispatcher` in
+ *       crt0.s for a example dispatcher. 
+ * NOTE: Changing the interrupt dispatcher should only be necessary 
+ *       when writing very low level code like an an operating system. 
+ *       Normal code wishing to install a interrupt service routine
+ *       for a particular interrupt should do so by writing the address 
+ *       of the isr to the corresponding entry in risc5_ivt[].
+ */
+
+extern uint32_t risc5_start_irq_dispatch;
+extern uint32_t risc5_default_irq_dispatcher;
+
+/* 
+ * Decode address of current irq dispatcher from branch instruction at address risc5_start_irq_dispatch.
+ * B Instruction: 
+ *             4      4     2       22
+ *      +------+------+------+------+------+------+------+------+
+ * F3:  | 1110 | 0111 | 00      off                             |
+ *      +------+------+------+------+------+------+------+------+
+ * Destination address = PC + 4 + off * 4, where PC is the current program counter.
+ */
+#define RISC5_GET_IRQ_DISPATCHER() ((&risc5_start_irq_dispatch) + 1 + (risc5_start_irq_dispatch & 0x3fffff))
+
+/* 
+ * Write a branch instruction to dispatcher_adress at address risc5_start_irq_dispatch.
+ */
+#define RISC5_SET_IRQ_DISPATCHER(dispatcher_adress)                                                                 \
+    do{                                                                                                             \
+        risc5_start_irq_dispatch = (0xe7000000 | ((uint32_t *)(dispatcher_adress) - &risc5_start_irq_dispatch - 1));   \
+    } while(0)
 
 #endif /* __RISC5_H */

--- a/lib/startup/crt0.s
+++ b/lib/startup/crt0.s
@@ -18,11 +18,32 @@
 	// export symbols
 	.GLOBAL	stack
 	.GLOBAL risc5_ivt
+    .GLOBAL risc5_start_irq_dispatch
+    .GLOBAL risc5_default_irq_dispatcher
 
 	.CODE
 
     B start
-irq_dispatch:
+risc5_start_irq_dispatch:
+    B risc5_default_irq_dispatcher
+risc5_ivt:
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+	.WORD 	default_isr
+risc5_default_irq_dispatcher:
 	GETS 	R13,	3		// first of all save the PSW, because of the flags
 	SUB	R14, R14, interrupt_frame_size		// calculate the new stack pointer for saving context
 	STW R0, R14, 0*4		// save R0
@@ -81,25 +102,9 @@ irq_dispatch:
 	ADD R14, R14, interrupt_frame_size	// restore the old stack pointer
 	PUTS R13, 3		// restore PSW
     RTI
-risc5_ivt:
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
-	.WORD 	default_isr
 default_isr:		// infinite loop, never returns
 	B default_isr
+
 start:
 	MOV	R14,stack	// set sp
 	MOV	R6,_bdata	// copy data segment

--- a/tests/test-change-interrupt-dispatcher/Makefile
+++ b/tests/test-change-interrupt-dispatcher/Makefile
@@ -1,0 +1,43 @@
+#
+# Makefile for a libc program
+#
+
+BUILD = ../../build
+
+SRC = test-change-interrupt-dispatcher.c
+EXE = test-change-interrupt-dispatcher
+MAP = test-change-interrupt-dispatcher.map
+BIN = test-change-interrupt-dispatcher.bin
+MEM = test-change-interrupt-dispatcher.mem
+
+all:		$(BIN) $(MEM)
+
+install:	$(BIN) $(MEM)
+
+boot:
+		$(BUILD)/bin/sim -p $(BUILD)/prom/boot.mem -s 001
+
+boot-connect:	$(BIN)
+		$(BUILD)/bin/sercomm $(BIN)
+
+run:		$(MEM)
+		$(BUILD)/bin/sim -i -r $(MEM) -s 001
+
+test:	$(MEM)
+		$(BUILD)/bin/sim -r $(MEM) -s 001
+
+run-connect:
+		$(BUILD)/bin/sercomm
+
+$(BIN):		$(EXE)
+		$(BUILD)/bin/load -p $(EXE) $(BIN)
+
+$(MEM):		$(BIN)
+		$(BUILD)/bin/bin2mem $(BIN) $(MEM)
+
+$(EXE):		$(SRC)
+		$(BUILD)/bin/lcc -A -Wo-ldmap=$(MAP) -o $(EXE) $(SRC)
+
+clean:
+		rm -f *~ $(EXE) $(MAP) $(BIN) $(MEM)
+		rm -f serial.dev

--- a/tests/test-change-interrupt-dispatcher/test-change-interrupt-dispatcher.c
+++ b/tests/test-change-interrupt-dispatcher/test-change-interrupt-dispatcher.c
@@ -1,0 +1,38 @@
+/*
+ * change interrupt dispatcher
+ */
+
+#include <risc5.h>
+
+void assertFn( const char *fileName, int line );
+#define Assert(expr) if (expr) {} else assertFn(__FILE__, __LINE__)
+
+int main(void) {
+    uint32_t old_start_irq_dispatch = risc5_start_irq_dispatch;
+    
+    uint32_t *current_irq_dispatcher = RISC5_GET_IRQ_DISPATCHER();
+    Assert(current_irq_dispatcher == &risc5_default_irq_dispatcher);
+
+    RISC5_SET_IRQ_DISPATCHER(&risc5_default_irq_dispatcher);
+    Assert(risc5_start_irq_dispatch == old_start_irq_dispatch);
+
+    current_irq_dispatcher = RISC5_GET_IRQ_DISPATCHER();
+    Assert(current_irq_dispatcher == &risc5_default_irq_dispatcher);
+
+    RISC5_SET_IRQ_DISPATCHER(0x1234);                   // Hypothetical irq dispatcher at address 0x1234
+    Assert(risc5_start_irq_dispatch == 0xe700048B);     // 0xe7000000 | ((0x1234 - 4 - 4) / 4)
+
+    current_irq_dispatcher = RISC5_GET_IRQ_DISPATCHER();
+    Assert(current_irq_dispatcher == (uint32_t*)0x1234);
+
+    *RISC5_IO_SIM_SHUTDOWN = 0x0;
+    return 0;
+}
+
+void assertFn( const char *fileName, int line )
+{
+    RISC5_DISABLE_INTERRUPTS();
+    ( void ) fileName;
+    ( void ) line;
+    *RISC5_IO_SIM_SHUTDOWN = 0x1;
+}


### PR DESCRIPTION
The default interrupt dispatching behaviour can be overwritten by writing a jump instruction to a user provided dispatcher at address 4 (risc5_start_irq_dispatch).

To do so, the macro `RISC5_SET_IRQ_DISPATCHER(dispatcher_adress)` is provided, which correctly encodes the jump to the new dispatcher.